### PR TITLE
las2peer 1.1.0

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="src/main"/>
 	<classpathentry kind="src" path="src/test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="lib/junit-4.13.1.jar"/>
 	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
 	<classpathentry kind="lib" path="lib/las2peer-bundle-1.1.0.jar"/>
 	<classpathentry kind="output" path="output"/>

--- a/.classpath
+++ b/.classpath
@@ -5,6 +5,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
 	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
-	<classpathentry kind="lib" path="lib/las2peer-bundle-0.8.3.jar"/>
+	<classpathentry kind="lib" path="lib/las2peer-bundle-1.1.0.jar"/>
 	<classpathentry kind="output" path="output"/>
 </classpath>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 jdk:
-  - openjdk8
+  - openjdk14
+before_install:
+  - wget http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.7-bin.tar.gz
+  - tar xvfvz apache-ant-1.10.7-bin.tar.gz
+  - export PATH=`pwd`/apache-ant-1.10.7/bin:$PATH
 install:
   - sudo apt-get install -y ant ant-optional
 sudo: false

--- a/README.md
+++ b/README.md
@@ -23,11 +23,7 @@ Please follow the instructions of this ReadMe to setup your basic service develo
 
 ### Java
 
-las2peer uses **Java 8**.
-
-If you use an Oracle Java version, please make sure you have **Java 8u162** or later installed, so that the Java Cryptography Extension (JCE) is enabled.
-Otherwise, you have to enable it manually.
-Each las2peer node performs an encryption self-test on startup.
+las2peer uses **Java 14**.
 
 ### Build Dependencies
 

--- a/build.xml
+++ b/build.xml
@@ -52,10 +52,10 @@
 	   <echo>Java/JVM version: ${ant.java.version}</echo> 
 	   <echo>Java/JVM detail version: ${java.version}</echo> 
 		<fail message="Unsupported Java version: ${ant.java.version}. 
-		  Make sure that the Java version is 1.8.">
+		  Make sure that the Java version is 14.">
 		  <condition>
 		  	<not>
-				<equals arg1="${ant.java.version}" arg2="1.8"/>
+				<equals arg1="${ant.java.version}" arg2="14"/>
 			</not>
 		  </condition>
 		</fail>

--- a/etc/ant_configuration/service.properties
+++ b/etc/ant_configuration/service.properties
@@ -2,4 +2,4 @@ service.version=1.0.0
 service.name=i5.las2peer.services.templateService
 service.path=i5/las2peer/services/templateService
 service.class=TemplateService
-core.version=0.8.3
+core.version=1.1.0

--- a/etc/ivy/ivy.xml
+++ b/etc/ivy/ivy.xml
@@ -12,9 +12,9 @@
         <!-- las2peer core -->
         <dependency org="i5" name="las2peer-bundle" rev="${core.version}" changing="true" conf="platform->*" />
         <!-- JUnit -->
-        <dependency org="junit" name="junit" rev="4.12" conf="platform->*" />
+        <dependency org="junit" name="junit" rev="4.13.1" conf="platform->*" />
         <!-- Jacoco -->
-        <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.5" conf="platform->default" />
+        <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.6" conf="platform->default" />
 
         <!-- service dependencies -->
         <!-- Add service dependencies here -->


### PR DESCRIPTION
This PR corresponds to issue https://github.com/rwth-acis/las2peer-template-project/issues/22.
It updates the template project to las2peer version 1.1.0 (https://github.com/rwth-acis/las2peer-template-project/commit/0d71beea928d935ed50485d205d426795c5774ab), also contains adjustments for Java 14 (https://github.com/rwth-acis/las2peer-template-project/commit/9c630ecc76f5fea56dfc2ec48860083808ecd367) and updates the dependencies JUnit and jacoco (https://github.com/rwth-acis/las2peer-template-project/commit/cf45a456b3068475b7d17dcae73f2ee03a400d0b).